### PR TITLE
Structure Improvement: add a gitignore file

### DIFF
--- a/Project/.gitignore
+++ b/Project/.gitignore
@@ -1,0 +1,19 @@
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs and databases #
+######################
+*.log
+*.sql
+*.sqlite
+
+# Jupyter Notebook
+.ipynb_checkpoints
+


### PR DESCRIPTION
A gitignore file is added to help git ignore some specific files that are useless for our project, such as the DS_Store which is generated automatically by Mac OS. The file can help make the repo environment more clear.