### PR TITLE
Coding etiquette: script reorganization

### DIFF
--- a/Project/vignette/MDS_Homework_3_revision.ipynb
+++ b/Project/vignette/MDS_Homework_3_revision.ipynb
@@ -1,13 +1,6 @@
 {
  "cells": [
   {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "1a) Cost of the event"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -15,6 +8,13 @@
    "source": [
     "import numpy as np\n",
     "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "1a) Cost of the event"
    ]
   },
   {


### PR DESCRIPTION
In this request, I didn't change any specific codes but moved model importations (eg. import pandas as pd) to the most front to make the whole structure more clear. All module imports in the future can be put together in the beginning like here to prevent them from interrupting the coherence of the script.