### PR TITLE
Coding etiquette: adjust function names

### DIFF
--- a/Project/vignette/MDS_Homework_3_revision.ipynb
+++ b/Project/vignette/MDS_Homework_3_revision.ipynb
@@ -297,7 +297,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def event_calc(num_of_people, type = 'private', cost = 400, tax_rate = 0.1):\n",
+    "def event_calc_1(num_of_people, type = 'private', cost = 400, tax_rate = 0.1):\n",
     "    assert cost > 0, 'Negative cost per person values are not allowed.'\n",
     "    assert 0 < tax_rate < .25, 'Tax rate must be between 0 and 0.25'\n",
     "    type_condition = ['wedding', 'corporate', 'private']\n",
@@ -368,7 +368,7 @@
    ],
    "source": [
     "# check to see if a right warning occurs with a wrong event type\n",
-    "event_calc(100, 'bachelor party', 200, 0.3)"
+    "event_calc_1(100, 'bachelor party', 200, 0.3)"
    ]
   },
   {
@@ -391,7 +391,7 @@
    ],
    "source": [
     "# check to see if a right warning occurs with a negtive cost per person\n",
-    "event_calc(100, 'wedding', -10)"
+    "event_calc_1(100, 'wedding', -10)"
    ]
   },
   {
@@ -409,7 +409,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def event_calc1(num_of_people, type = 'wedding', cost = 450, tax_rate = 0.1):\n",
+    "def event_calc_2(num_of_people, type = 'wedding', cost = 450, tax_rate = 0.1):\n",
     "    \n",
     "    type_condition = ['wedding', 'corporate', 'private']\n",
     "    \n",
@@ -479,7 +479,7 @@
    ],
    "source": [
     "# check to see if a warning would appear as a printed message  \n",
-    "event_calc1(100, 'wedding', 120, -0.1) "
+    "event_calc_2(100, 'wedding', 120, -0.1) "
    ]
   }
  ],


### PR DESCRIPTION
I noticed in the original script two functions are defined with the same name 'event_calc'. Using names of existing functions may make collaborators difficult to follow and differentiate. So, I renamed the function names and the impacted code followed.